### PR TITLE
preallocate works on int64, not uint64

### DIFF
--- a/preallocate_linux.go
+++ b/preallocate_linux.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 )
 
-func preallocExtend(f *os.File, sizeInBytes uint64) error {
+func preallocExtend(f *os.File, sizeInBytes int64) error {
 	// use mode = 0 to change size
 	err := syscall.Fallocate(int(f.Fd()), 0, 0, sizeInBytes)
 	if err != nil {


### PR DESCRIPTION
This was done to make sure linux version builds and passes tests